### PR TITLE
fix: use binary blobs directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
   "devDependencies": {
     "aegir": "^12.4.0",
     "chai": "^4.1.2",
-    "dirty-chai": "^2.0.1",
-    "ipfs-block": "~0.6.1",
-    "multihashing-async": "~0.4.7"
+    "dirty-chai": "^2.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,13 @@ const CID = require('cids')
 module.exports = {
   resolver: {
     multicodec: 'raw',
-    resolve: (ipfsBlock, path, callback) => {
+    resolve: (binaryBlob, path, callback) => {
       callback(null, {
-        value: ipfsBlock.data,
+        value: binaryBlob,
         remainderPath: ''
       })
     },
-    tree: (ipfsBlock, options, callback) => {
+    tree: (binaryBlob, options, callback) => {
       callback(null, [])
     }
   },


### PR DESCRIPTION
IPLD shouldn't need to know about IPFS. Hence work directly with
the binary data instead of using an IPFS block.

This is part of https://github.com/ipld/interface-ipld-format/issues/21

BREAKING CHANGE: Everyone calling the functions of `resolve` need to
pass in the binary data instead of an IPFS block.

So if your input is an IPFS block, the code changes from

    resolver.resolve(block, path, (err, result) => {…}

to

    resolver.resolve(block.data, path, (err, result) => {…}