### PR TITLE
Allow options to be ommitted in resolver.tree

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ module.exports = {
       })
     },
     tree: (binaryBlob, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+      }
       callback(null, [])
     }
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -39,4 +39,12 @@ describe('raw codec', () => {
       expect(paths.length).to.eql(0)
     })
   })
+
+  it('resolver.tree option parameter can be ignored', () => {
+    resolver.tree(testBlob, (err, paths) => {
+      expect(err).to.not.exist()
+      expect(Array.isArray(paths)).to.eql(true)
+      expect(paths.length).to.eql(0)
+    })
+  })
 })


### PR DESCRIPTION
Just a small fix that solves #4 