### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@
 
 > JavaScript Implementation of the IPLD Format Raw Node.
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)
 - [Usage](#usage)
 - [API](#api)
-- [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -57,10 +60,6 @@ TODO
 ### `raw.util.serialize`
 
 ### `raw.util.deserialize`
-
-## Maintainers
-
-[@kumavis](https://github.com/kumavis)
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-raw",
   "version": "2.0.0",
   "description": "JavaScript implementation of the IPLD raw format.",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "test": "aegir test",
@@ -23,7 +24,6 @@
     "type": "git",
     "url": "git+https://github.com/ipld/js-ipld-raw.git"
   },
-  "author": "kumavis",
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",
     "Richard Schneider <makaretu@gmail.com>",


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md