### PR TITLE
chore: remove coverage-publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "release": "aegir release",
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
-    "build": "aegir build",
-    "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "build": "aegir build"
   },
   "pre-push": [
     "lint",


### PR DESCRIPTION
Coveralls is no longer used on the CI.

This is part of https://github.com/ipfs/aegir/issues/263.