### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-raw#readme",
   "dependencies": {
-    "cids": "~0.5.2",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "multihashing-async": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs created by this module are base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73