### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,11 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-raw#readme",
   "dependencies": {
-    "cids": "~0.8.0",
+    "cids": "^0.8.1",
     "multicodec": "^1.0.1",
-    "multihashing-async": "~0.8.1"
+    "multihashing-async": "^0.8.1"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "multihashes": "~0.4.19"
+    "aegir": "^22.0.0"
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,13 +1,10 @@
 'use strict'
 /* eslint-env mocha */
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 const ipldRaw = require('../src/index')
 const resolver = ipldRaw.resolver
-const multihash = require('multihashes')
+const multihash = require('multihashing-async').multihash
 const multicodec = require('multicodec')
 
 describe('raw codec', () => {


### PR DESCRIPTION
Uses `^` for versions in line with the rest of the codebase.

Also removes the `multihashes` dep in favour of the one exported from
`multihashing-async` and removes `chai`/`dirty-chai` in favour of the
one exported by `aegir`.