### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,12 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-raw#readme",
   "dependencies": {
-    "cids": "^0.8.1",
-    "multicodec": "^1.0.1",
-    "multihashing-async": "^0.8.1"
+    "cids": "ipld/js-cid#fix/support-uint8arrays",
+    "multicodec": "^2.0.0",
+    "multihashing-async": "^2.0.0"
   },
   "devDependencies": {
-    "aegir": "^22.0.0"
+    "aegir": "^25.0.0",
+    "uint8arrays": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-raw#readme",
   "dependencies": {
-    "cids": "ipld/js-cid#fix/support-uint8arrays",
+    "cids": "^1.0.0",
     "multicodec": "^2.0.0",
     "multihashing-async": "^2.0.0"
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,9 +6,10 @@ const ipldRaw = require('../src/index')
 const resolver = ipldRaw.resolver
 const multihash = require('multihashing-async').multihash
 const multicodec = require('multicodec')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('raw codec', () => {
-  const testData = Buffer.from('test data')
+  const testData = uint8ArrayFromString('test data')
   const testBlob = ipldRaw.util.serialize(testData)
 
   it('multicodec is raw', () => {
@@ -39,7 +40,7 @@ describe('raw codec', () => {
 })
 
 describe('raw util', () => {
-  const rawData = Buffer.from('some raw data')
+  const rawData = uint8ArrayFromString('some raw data')
 
   it('serialize is noop', () => {
     const result = ipldRaw.util.serialize(rawData)


### PR DESCRIPTION
Depends on:

- [x] https://github.com/multiformats/js-cid/pull/117

BREAKING CHANGE:

- `util.serialize` now returns a Uint8Array
- `util.cid` returns v1 `CID`s